### PR TITLE
chore: log using slog DEVOPS-366

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ Run an individual tests using `go test -run`.
 
 * producer is not implement in the same way as consumer. This means it does not re-connect for you.
 We don't know if we will implement the producer in the same way as the consumer.
-* logging cannot be configured/turned off. We could define an interface for the
-  libraries logging needs. Clients can then pass in any logger. Can be as
-  simple as https://github.com/go-redis/redis/pull/1285
-  or simply use and accept an slog.Logger
 * re-connection logic does not give you any insight into its state. We could
   provide callbacks that are invoked on disconnect/reconnect like
   https://pkg.go.dev/github.com/nats-io/nats.go#DisconnectErrHandler
@@ -104,3 +100,5 @@ new methods using Context do not all seem to be correctly using it https://githu
   can see in the signature of the receiver passed to Consume(). This is something we could do as we
   do not expose any other AMQP library specifics.
 * we do not support different topologies. We only consume from the default exchange.
+* we are logging using [slog](https://pkg.go.dev/log/slog). You can pass in an `slog.Logger`
+otherwise we are using the `slog.Default()`.

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 # Consume
 
-* create logging interface and pass that to NewConsumer() and use logger instead of fmt.Print
 * make the queue durable. test messages are not lost if there is no consumer.
 
 # Publish
@@ -13,11 +12,6 @@
 
 * setup logger for tests. So we can clearly differentiate it with the clients logs.
   Maybe use https://pkg.go.dev/github.com/testcontainers/testcontainers-go#TestLogger
-* think about how to best separate the test helpers. Having rabbitmq and toxiproxy
-  helpers in the same package is a bit awkward with regards to their options.
-  Own packages would be nice, but they should obviously not be included in the
-  binary.
-* skipping a test seems to start rabbitmq in the skipped test
-* what is the default test timeout in go? seems like 10min. make sure tests fail earlier!
-* test different scenarios and if tests would fail according to timeouts and
-context cancellations
+* what is a good use of context in tests. testcontainers accept a context in their signatures.
+Should we create a context with timeouts that make sense to us? or should these also take into
+account what the `-timeout` flag is with which the tests are run?

--- a/pkg/rabbitmq/consumer_test.go
+++ b/pkg/rabbitmq/consumer_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // timeout waiting on messages or other queue operations
-var timeout time.Duration = 20 * time.Second
+var timeout time.Duration = 30 * time.Second
 
 func TestNewConsumer(t *testing.T) {
 	amqp := inttest.SetupRabbitMQ(t)

--- a/pkg/rabbitmq/consumer_test.go
+++ b/pkg/rabbitmq/consumer_test.go
@@ -3,6 +3,8 @@ package rabbitmq_test
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -28,7 +30,7 @@ func TestNewConsumer(t *testing.T) {
 
 	t.Run("ConsumerPrefixValid", func(t *testing.T) {
 		consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
-			rabbitmq.WithConsumerPrefix(strings.Repeat("a", maxPrefix)),
+			rabbitmq.WithConsumerTagPrefix(strings.Repeat("a", maxPrefix)),
 		)
 
 		assert.NoError(t, err,
@@ -41,7 +43,7 @@ func TestNewConsumer(t *testing.T) {
 
 	t.Run("ConsumerPrefixInvalid", func(t *testing.T) {
 		consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
-			rabbitmq.WithConsumerPrefix(strings.Repeat("a", maxPrefix+1)),
+			rabbitmq.WithConsumerTagPrefix(strings.Repeat("a", maxPrefix+1)),
 		)
 
 		assert.ErrorContainsf(t, err,
@@ -70,7 +72,11 @@ func TestConsumeFailsDueToClosedConnection(t *testing.T) {
 
 	amqp := inttest.SetupRabbitMQ(t)
 
-	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI)
+	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
+		rabbitmq.WithConnectionName(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
+	)
 	require.NoError(err)
 
 	// closing the connection before call to Consume()
@@ -92,7 +98,11 @@ func TestConsumeFailsDueToDifferingQueueProperties(t *testing.T) {
 
 	amqp := inttest.SetupRabbitMQ(t)
 
-	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI)
+	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
+		rabbitmq.WithConnectionName(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
+	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
 
@@ -127,7 +137,8 @@ func TestConsume(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
@@ -176,7 +187,8 @@ func TestConsumeReconnectsConnection(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
@@ -233,7 +245,8 @@ func TestConsumeRegistersConsumersAgain(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
@@ -291,7 +304,8 @@ func TestConsumeRegistersConsumersAgainAndRedeclaresQueues(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
@@ -345,7 +359,8 @@ func TestCancel(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 	defer func() { require.NoError(consumer.Close()) }()
@@ -420,7 +435,8 @@ func TestClose(t *testing.T) {
 
 	consumer, err := rabbitmq.NewConsumer(amqp.ProxiedURI,
 		rabbitmq.WithConnectionName(t.Name()),
-		rabbitmq.WithConsumerPrefix(t.Name()),
+		rabbitmq.WithConsumerTagPrefix(t.Name()),
+		rabbitmq.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
 	)
 	require.NoError(err)
 


### PR DESCRIPTION
use the slog.Default() logger by default so you can use the consumer if you do not care about how logging is configured. Allow setting the logger with an option. Show how this is done in the example consumer with a logger from which we create a new one for the consumer that uses a group

stick to word https://www.rabbitmq.com/docs/consumers#consumer-tags instead of consumer ID which does not seem to be used.